### PR TITLE
Fix bug in "create_users_table" migration.

### DIFF
--- a/backend/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/backend/database/migrations/2014_10_12_000000_create_users_table.php
@@ -21,7 +21,7 @@ class CreateUsersTable extends Migration
             $table
                 ->foreign('role_id')
                 ->references('id')
-                ->on('users');
+                ->on('roles');
         });
     }
 


### PR DESCRIPTION
Foreign key "role_id" reference from "users" table to "roles" table.