### PR TITLE
Fixed bugs in field about yourself

### DIFF
--- a/frontend/src/bundles/auth/components/AdditionalForm.vue
+++ b/frontend/src/bundles/auth/components/AdditionalForm.vue
@@ -162,10 +162,12 @@
     <validation-provider
       v-slot="{ errors }"
       name="about"
-      rules="required|min:10"
+      rules="required|min:10,description|max:500,description"
     >
       <v-textarea
         v-model="about"
+        auto-grow
+        counter="500"
         clearable
         clear-icon="mdi-close-circle"
         rounded

--- a/frontend/src/bundles/auth/components/SetUpForm.vue
+++ b/frontend/src/bundles/auth/components/SetUpForm.vue
@@ -3,7 +3,7 @@
     <validation-provider
       v-slot="{ errors }"
       name="name"
-      rules="required|min:3"
+      rules="required|min:3,name"
     >
       <v-text-field
         v-model="fullName"

--- a/frontend/src/plugins/veeValidate.ts
+++ b/frontend/src/plugins/veeValidate.ts
@@ -30,7 +30,7 @@ extend('confirmed', {
 extend('min', {
   ...min,
   params: ['length', 'name'],
-  message: 'Your {name} about yourself must be at least {length} characters',
+  message: 'Your {name} must be at least {length} characters',
 });
 
 extend('max', {

--- a/frontend/src/plugins/veeValidate.ts
+++ b/frontend/src/plugins/veeValidate.ts
@@ -4,6 +4,7 @@ import {
   email,
   confirmed,
   min,
+  max,
 } from 'vee-validate/dist/rules';
 
 extend('required', {
@@ -29,7 +30,13 @@ extend('confirmed', {
 extend('min', {
   ...min,
   params: ['length', 'name'],
-  message: 'Your {name} must be at least {length} characters',
+  message: 'Your {name} about yourself must be at least {length} characters',
+});
+
+extend('max', {
+  ...max,
+  params: ['length', 'name'],
+  message: 'Your {name} about yourself must be no more {length} characters',
 });
 
 extend('phone', {


### PR DESCRIPTION
The “close” button is superimposed on the scroll in the “about yourself ” field after entering text 
and 
The “resize” button is superimposed on the “about yourself ” field after entering text