### PR TITLE
Fix settings link from /settings (empty template) to /main-settings-details

### DIFF
--- a/frontend/src/bundles/main/components/NavbarComponent.vue
+++ b/frontend/src/bundles/main/components/NavbarComponent.vue
@@ -199,7 +199,7 @@ export default {
   computed: {
     menuUser() {
       return [
-        { title: 'Settings', name: 'main-settings' },
+        { title: 'Settings', name: 'main-settings-details' },
         { title: 'Logout', name: 'logout' },
       ];
     },


### PR DESCRIPTION
/settings page in navbar lead to empty parent template. Changed link to child page /settings-update-info